### PR TITLE
r.what.color: add json support

### DIFF
--- a/include/grass/colors.h
+++ b/include/grass/colors.h
@@ -7,23 +7,25 @@
    display. If support for named colors is needed it should go in
    G_str_to_color. */
 
-#define BLACK   1
-#define RED     2
-#define GREEN   3
-#define BLUE    4
-#define YELLOW  5
-#define CYAN    6
-#define MAGENTA 7
-#define WHITE   8
-#define GRAY    9
-#define ORANGE  10
-#define AQUA    11
-#define INDIGO  12
-#define VIOLET  13
-#define BROWN   14
+#define BLACK               1
+#define RED                 2
+#define GREEN               3
+#define BLUE                4
+#define YELLOW              5
+#define CYAN                6
+#define MAGENTA             7
+#define WHITE               8
+#define GRAY                9
+#define ORANGE              10
+#define AQUA                11
+#define INDIGO              12
+#define VIOLET              13
+#define BROWN               14
 
-#define GREY    GRAY
-#define PURPLE  VIOLET
+#define GREY                GRAY
+#define PURPLE              VIOLET
+
+#define COLOR_STRING_LENGTH 30
 
 /* These can be in any order. They must match the lookup strings in the table
  * below. */
@@ -42,6 +44,15 @@ struct color_name {
     const char *name;
     int number;
 };
+
+/*!
+   \typedef ColorFormat
+   \brief  Color format identifiers (enum)
+
+   Identifiers of all recognized color formats.
+
+ */
+typedef enum { RGB, HEX, HSV, TRIPLET } ColorFormat;
 
 #include <grass/defs/colors.h>
 

--- a/include/grass/defs/colors.h
+++ b/include/grass/defs/colors.h
@@ -1,6 +1,8 @@
 #ifndef GRASS_COLORSDEFS_H
 #define GRASS_COLORSDEFS_H
 
+#include <grass/gis.h>
+
 int G_num_standard_colors(void);
 struct color_rgb G_standard_color_rgb(int);
 int G_num_standard_color_names(void);

--- a/include/grass/defs/colors.h
+++ b/include/grass/defs/colors.h
@@ -7,5 +7,6 @@ int G_num_standard_color_names(void);
 const struct color_name *G_standard_color_name(int);
 int G_str_to_color(const char *, int *, int *, int *);
 void G_rgb_to_hsv(int, int, int, float *, float *, float *);
+void G_color_to_str(int, int, int, ColorFormat, char *);
 
 #endif

--- a/include/grass/defs/colors.h
+++ b/include/grass/defs/colors.h
@@ -8,5 +8,6 @@ const struct color_name *G_standard_color_name(int);
 int G_str_to_color(const char *, int *, int *, int *);
 void G_rgb_to_hsv(int, int, int, float *, float *, float *);
 void G_color_to_str(int, int, int, ColorFormat, char *);
+ColorFormat G_option_to_color_format(const struct Option *);
 
 #endif

--- a/include/grass/defs/raster.h
+++ b/include/grass/defs/raster.h
@@ -4,6 +4,7 @@
 #include <stdbool.h>
 
 #include <grass/gis.h>
+#include <grass/colors.h>
 
 /* --- ANSI prototypes for the lib/raster functions --- */
 

--- a/include/grass/raster.h
+++ b/include/grass/raster.h
@@ -168,15 +168,6 @@ enum History_field {
     HIST_NUM_FIELDS
 };
 
-/*!
-   \typedef ColorFormat
-   \brief  Color format identifiers (enum)
-
-   Identifiers of all recognized color formats.
-
- */
-typedef enum { RGB, HEX, HSV, TRIPLET } ColorFormat;
-
 /*! \brief Raster history info (metadata) */
 struct History {
     /*! \brief Array of fields (see \ref History_field for details) */

--- a/lib/gis/color_str.c
+++ b/lib/gis/color_str.c
@@ -17,6 +17,7 @@
 #include <string.h>
 
 #include <grass/gis.h>
+#include <grass/glocale.h>
 #include <grass/colors.h>
 
 /* The order in this table is important! It will be indexed by color number */
@@ -229,4 +230,41 @@ void G_color_to_str(int r, int g, int b, ColorFormat clr_frmt, char *str)
         snprintf(str, COLOR_STRING_LENGTH, "%d:%d:%d", r, g, b);
         break;
     }
+}
+
+/*!
+   \brief Get color format from the option.
+
+   \code
+   ColorFormat colorFormat;
+   struct Option *color_format;
+
+   color_format = G_define_standard_option(G_OPT_C_FORMAT);
+
+   if (G_parser(argc, argv))
+   exit(EXIT_FAILURE);
+
+   colorFormat = G_option_to_color_format(color_format);
+   \endcode
+
+   \param option pointer to color format option
+
+   \return allocated ColorFormat
+ */
+ColorFormat G_option_to_color_format(const struct Option *option)
+{
+    if (strcmp(option->answer, "rgb") == 0) {
+        return RGB;
+    }
+    if (strcmp(option->answer, "triplet") == 0) {
+        return TRIPLET;
+    }
+    if (strcmp(option->answer, "hsv") == 0) {
+        return HSV;
+    }
+    if (strcmp(option->answer, "hex") == 0) {
+        return HEX;
+    }
+
+    G_fatal_error(_("Unknown color format '%s'"), option->answer);
 }

--- a/lib/gis/color_str.c
+++ b/lib/gis/color_str.c
@@ -196,3 +196,37 @@ void G_rgb_to_hsv(int r, int g, int b, float *h, float *s, float *v)
 
     *v = cmax * 100.0f;
 }
+
+/*!
+   \brief Parse red,green,blue and set color string
+
+   \param r red component of RGB color
+   \param g green component of RGB color
+   \param b blue component of RGB color
+   \param clr_frmt color format to be used (RGB, HEX, HSV, TRIPLET).
+   \param[out] str color string
+ */
+void G_color_to_str(int r, int g, int b, ColorFormat clr_frmt, char *str)
+{
+    float h, s, v;
+
+    switch (clr_frmt) {
+    case RGB:
+        snprintf(str, COLOR_STRING_LENGTH, "rgb(%d, %d, %d)", r, g, b);
+        break;
+
+    case HEX:
+        snprintf(str, COLOR_STRING_LENGTH, "#%02X%02X%02X", r, g, b);
+        break;
+
+    case HSV:
+        G_rgb_to_hsv(r, g, b, &h, &s, &v);
+        snprintf(str, COLOR_STRING_LENGTH, "hsv(%d, %d, %d)", (int)h, (int)s,
+                 (int)v);
+        break;
+
+    case TRIPLET:
+        snprintf(str, COLOR_STRING_LENGTH, "%d:%d:%d", r, g, b);
+        break;
+    }
+}

--- a/raster/CMakeLists.txt
+++ b/raster/CMakeLists.txt
@@ -677,7 +677,7 @@ build_program_in_subdir(r.water.outlet DEPENDS grass_gis grass_raster)
 build_program_in_subdir(r.what DEPENDS grass_gis grass_raster grass_vector
                         grass_parson)
 
-build_program_in_subdir(r.what.color DEPENDS grass_gis grass_raster)
+build_program_in_subdir(r.what.color DEPENDS grass_gis grass_raster grass_parson)
 
 build_program_in_subdir(
   r.in.lidar

--- a/raster/r.category/local_proto.h
+++ b/raster/r.category/local_proto.h
@@ -20,8 +20,6 @@
 
 #include <grass/parson.h>
 
-#define COLOR_STRING_LENGTH 30
-
 enum OutputFormat { PLAIN, JSON };
 enum ColorOutput { NONE, RGB_OUTPUT, HEX_OUTPUT, TRIPLET_OUTPUT, HSV_OUTPUT };
 

--- a/raster/r.colors.out/raster3d_main.c
+++ b/raster/r.colors.out/raster3d_main.c
@@ -87,18 +87,7 @@ int main(int argc, char **argv)
     }
 
     if (strcmp(opt.format->answer, "json") == 0) {
-        if (strcmp(opt.color_format->answer, "rgb") == 0) {
-            clr_frmt = RGB;
-        }
-        else if (strcmp(opt.color_format->answer, "triplet") == 0) {
-            clr_frmt = TRIPLET;
-        }
-        else if (strcmp(opt.color_format->answer, "hsv") == 0) {
-            clr_frmt = HSV;
-        }
-        else {
-            clr_frmt = HEX;
-        }
+        clr_frmt = G_option_to_color_format(opt.color_format);
         Rast_print_json_colors(&colors, range.min, range.max, fp,
                                flag.p->answer ? 1 : 0, clr_frmt);
     }

--- a/raster/r.colors.out/raster_main.c
+++ b/raster/r.colors.out/raster_main.c
@@ -86,18 +86,7 @@ int main(int argc, char **argv)
     }
 
     if (strcmp(opt.format->answer, "json") == 0) {
-        if (strcmp(opt.color_format->answer, "rgb") == 0) {
-            clr_frmt = RGB;
-        }
-        else if (strcmp(opt.color_format->answer, "triplet") == 0) {
-            clr_frmt = TRIPLET;
-        }
-        else if (strcmp(opt.color_format->answer, "hsv") == 0) {
-            clr_frmt = HSV;
-        }
-        else {
-            clr_frmt = HEX;
-        }
+        clr_frmt = G_option_to_color_format(opt.color_format);
         Rast_print_json_colors(&colors, range.min, range.max, fp,
                                flag.p->answer ? 1 : 0, clr_frmt);
     }

--- a/raster/r.what.color/Makefile
+++ b/raster/r.what.color/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../..
 
 PGM = r.what.color
 
-LIBES = $(RASTERLIB) $(GISLIB)
+LIBES = $(RASTERLIB) $(GISLIB) $(PARSONLIB)
 DEPENDENCIES = $(RASTERDEP) $(GISDEP)
 
 include $(MODULE_TOPDIR)/include/Make/Module.make

--- a/raster/r.what.color/main.c
+++ b/raster/r.what.color/main.c
@@ -21,49 +21,145 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
+#include <grass/colors.h>
 #include <grass/gis.h>
+#include <grass/parson.h>
 #include <grass/raster.h>
 #include <grass/glocale.h>
+
+enum OutputFormat { PLAIN, JSON };
 
 static const char *fmt;
 
 static int do_value(const char *buf, RASTER_MAP_TYPE type,
-                    struct Colors *colors)
+                    struct Colors *colors, enum OutputFormat outputFormat,
+                    ColorFormat colorFormat, JSON_Array *root_array,
+                    JSON_Value *root_value)
 {
     CELL ival;
     DCELL fval;
     int red, grn, blu;
+    char color_str[COLOR_STRING_LENGTH];
+
+    JSON_Object *color_object = NULL;
+    JSON_Value *color_value = NULL;
+
+    if (outputFormat == JSON) {
+        color_value = json_value_init_object();
+        if (color_value == NULL) {
+            json_value_free(root_value);
+            G_fatal_error(
+                _("Failed to initialize JSON object. Out of memory?"));
+        }
+        color_object = json_object(color_value);
+    }
 
     switch (type) {
     case CELL_TYPE:
         if (sscanf(buf, "%d", &ival) != 1) {
-            fprintf(stdout, "*: *\n");
+            switch (outputFormat) {
+            case PLAIN:
+                fprintf(stdout, "*: *\n");
+                break;
+
+            case JSON:
+                json_object_set_string(color_object, "value", "*");
+                json_object_set_string(color_object, "color", "*");
+                json_array_append_value(root_array, color_value);
+                break;
+            }
             return 0;
         }
         if (!Rast_get_c_color(&ival, &red, &grn, &blu, colors)) {
-            fprintf(stdout, "%d: *\n", ival);
+            switch (outputFormat) {
+            case PLAIN:
+                fprintf(stdout, "%d: *\n", ival);
+                break;
+
+            case JSON:
+                json_object_set_number(color_object, "value", ival);
+                json_object_set_string(color_object, "color", "*");
+                json_array_append_value(root_array, color_value);
+                break;
+            }
             return 0;
         }
-        fprintf(stdout, "%d: ", ival);
-        fprintf(stdout, fmt, red, grn, blu);
-        fprintf(stdout, "\n");
+        switch (outputFormat) {
+        case PLAIN:
+            fprintf(stdout, "%d: ", ival);
+            if (strcmp(fmt, "plain") != 0) {
+                fprintf(stdout, fmt, red, grn, blu);
+            }
+            else {
+                G_color_to_str(red, grn, blu, colorFormat, color_str);
+                fprintf(stdout, "%s", color_str);
+            }
+            fprintf(stdout, "\n");
+            break;
+
+        case JSON:
+            json_object_set_number(color_object, "value", ival);
+            G_color_to_str(red, grn, blu, colorFormat, color_str);
+            json_object_set_string(color_object, "color", color_str);
+            json_array_append_value(root_array, color_value);
+            break;
+        }
         return 1;
 
     case FCELL_TYPE:
     case DCELL_TYPE:
         if (sscanf(buf, "%lf", &fval) != 1) {
-            fprintf(stdout, "*: *\n");
+            switch (outputFormat) {
+            case PLAIN:
+                fprintf(stdout, "*: *\n");
+                break;
+
+            case JSON:
+                json_object_set_string(color_object, "value", "*");
+                json_object_set_string(color_object, "color", "*");
+                json_array_append_value(root_array, color_value);
+                break;
+            }
             return 0;
         }
         if (!Rast_get_d_color(&fval, &red, &grn, &blu, colors)) {
-            fprintf(stdout, "%.15g: *\n", fval);
+            switch (outputFormat) {
+            case PLAIN:
+                fprintf(stdout, "%.15g: *\n", fval);
+                break;
+
+            case JSON:
+                json_object_set_number(color_object, "value", fval);
+                json_object_set_string(color_object, "color", "*");
+                json_array_append_value(root_array, color_value);
+                break;
+            }
             return 0;
         }
-        fprintf(stdout, "%.15g: ", fval);
-        fprintf(stdout, fmt, red, grn, blu);
-        fprintf(stdout, "\n");
+        switch (outputFormat) {
+        case PLAIN:
+            fprintf(stdout, "%.15g: ", fval);
+            if (strcmp(fmt, "plain") != 0) {
+                fprintf(stdout, fmt, red, grn, blu);
+            }
+            else {
+                G_color_to_str(red, grn, blu, colorFormat, color_str);
+                fprintf(stdout, "%s", color_str);
+            }
+            fprintf(stdout, "\n");
+            break;
+
+        case JSON:
+            json_object_set_number(color_object, "value", fval);
+            G_color_to_str(red, grn, blu, colorFormat, color_str);
+            json_object_set_string(color_object, "color", color_str);
+            json_array_append_value(root_array, color_value);
+            break;
+        }
         return 1;
     default:
+        if (outputFormat == JSON)
+            json_value_free(root_value);
         G_fatal_error("Invalid map type %d", type);
         return 0;
     }
@@ -73,7 +169,7 @@ int main(int argc, char **argv)
 {
     struct GModule *module;
     struct {
-        struct Option *input, *value, *format;
+        struct Option *input, *value, *format, *color_format;
     } opt;
     struct {
         struct Flag *i;
@@ -81,6 +177,12 @@ int main(int argc, char **argv)
     const char *name;
     struct Colors colors;
     RASTER_MAP_TYPE type;
+
+    enum OutputFormat outputFormat;
+    ColorFormat colorFormat;
+
+    JSON_Array *root_array = NULL;
+    JSON_Value *root_value = NULL;
 
     G_gisinit(argv[0]);
 
@@ -104,7 +206,12 @@ int main(int argc, char **argv)
     opt.format->type = TYPE_STRING;
     opt.format->required = NO;
     opt.format->answer = "%d:%d:%d";
-    opt.format->description = _("Output format (printf-style)");
+    opt.format->description = _("[DEPRECATED] Output format (printf-style);"
+                                "plain;Plain text output;"
+                                "json;JSON (JavaScript Object Notation);");
+
+    opt.color_format = G_define_standard_option(G_OPT_C_FORMAT);
+    opt.color_format->guisection = _("Color");
 
     flag.i = G_define_flag();
     flag.i->key = 'i';
@@ -127,6 +234,41 @@ int main(int argc, char **argv)
 
     fmt = opt.format->answer;
 
+    if (strcmp(fmt, "json") == 0) {
+        outputFormat = JSON;
+
+        root_value = json_value_init_array();
+        if (root_value == NULL) {
+            G_fatal_error(_("Failed to initialize JSON array. Out of memory?"));
+        }
+        root_array = json_array(root_value);
+    }
+    else {
+        outputFormat = PLAIN;
+
+        if (strcmp(fmt, "plain") != 0) {
+            G_warning(
+                _("The printf-style output format is deprecated and will "
+                  "be removed in a future release. Please use the "
+                  "'color_format' option instead, along with 'format=plain'."));
+        }
+    }
+
+    if (strcmp(fmt, "plain") == 0 || strcmp(fmt, "json") == 0) {
+        if (strcmp(opt.color_format->answer, "rgb") == 0) {
+            colorFormat = RGB;
+        }
+        else if (strcmp(opt.color_format->answer, "triplet") == 0) {
+            colorFormat = TRIPLET;
+        }
+        else if (strcmp(opt.color_format->answer, "hsv") == 0) {
+            colorFormat = HSV;
+        }
+        else {
+            colorFormat = HEX;
+        }
+    }
+
     if (flag.i->answer) {
         for (;;) {
             char buf[64];
@@ -134,7 +276,8 @@ int main(int argc, char **argv)
             if (!fgets(buf, sizeof(buf), stdin))
                 break;
 
-            do_value(buf, type, &colors);
+            do_value(buf, type, &colors, outputFormat, colorFormat, root_array,
+                     root_value);
         }
     }
     else if (opt.value->answer) {
@@ -142,7 +285,20 @@ int main(int argc, char **argv)
         int i;
 
         for (i = 0; ans = opt.value->answers[i], ans; i++)
-            do_value(ans, type, &colors);
+            do_value(ans, type, &colors, outputFormat, colorFormat, root_array,
+                     root_value);
+    }
+
+    if (outputFormat == JSON) {
+        char *serialized_string = NULL;
+        serialized_string = json_serialize_to_string_pretty(root_value);
+        if (serialized_string == NULL) {
+            json_value_free(root_value);
+            G_fatal_error(_("Failed to initialize pretty JSON string."));
+        }
+        puts(serialized_string);
+        json_free_serialized_string(serialized_string);
+        json_value_free(root_value);
     }
 
     return EXIT_SUCCESS;

--- a/raster/r.what.color/main.c
+++ b/raster/r.what.color/main.c
@@ -63,8 +63,8 @@ static int do_value(const char *buf, RASTER_MAP_TYPE type,
                 break;
 
             case JSON:
-                json_object_set_string(color_object, "value", "*");
-                json_object_set_string(color_object, "color", "*");
+                json_object_set_null(color_object, "value");
+                json_object_set_null(color_object, "color");
                 json_array_append_value(root_array, color_value);
                 break;
             }
@@ -78,7 +78,7 @@ static int do_value(const char *buf, RASTER_MAP_TYPE type,
 
             case JSON:
                 json_object_set_number(color_object, "value", ival);
-                json_object_set_string(color_object, "color", "*");
+                json_object_set_null(color_object, "color");
                 json_array_append_value(root_array, color_value);
                 break;
             }
@@ -115,8 +115,8 @@ static int do_value(const char *buf, RASTER_MAP_TYPE type,
                 break;
 
             case JSON:
-                json_object_set_string(color_object, "value", "*");
-                json_object_set_string(color_object, "color", "*");
+                json_object_set_null(color_object, "value");
+                json_object_set_null(color_object, "color");
                 json_array_append_value(root_array, color_value);
                 break;
             }
@@ -130,7 +130,7 @@ static int do_value(const char *buf, RASTER_MAP_TYPE type,
 
             case JSON:
                 json_object_set_number(color_object, "value", fval);
-                json_object_set_string(color_object, "color", "*");
+                json_object_set_null(color_object, "color");
                 json_array_append_value(root_array, color_value);
                 break;
             }
@@ -206,11 +206,15 @@ int main(int argc, char **argv)
     opt.format->type = TYPE_STRING;
     opt.format->required = NO;
     opt.format->answer = "%d:%d:%d";
-    opt.format->description = _("[DEPRECATED] Output format (printf-style);"
-                                "plain;Plain text output;"
-                                "json;JSON (JavaScript Object Notation);");
+    opt.format->label =
+        _("Output format ('plain', 'json', or printf-style string)");
+    opt.format->description = _("Output format printf-style is deprecated, use "
+                                "'color_format' option instead.");
 
     opt.color_format = G_define_standard_option(G_OPT_C_FORMAT);
+    opt.color_format->description =
+        _("Color format for output values. Applies only when format is set to "
+          "'plain' or 'json'.");
     opt.color_format->guisection = _("Color");
 
     flag.i = G_define_flag();
@@ -255,18 +259,7 @@ int main(int argc, char **argv)
     }
 
     if (strcmp(fmt, "plain") == 0 || strcmp(fmt, "json") == 0) {
-        if (strcmp(opt.color_format->answer, "rgb") == 0) {
-            colorFormat = RGB;
-        }
-        else if (strcmp(opt.color_format->answer, "triplet") == 0) {
-            colorFormat = TRIPLET;
-        }
-        else if (strcmp(opt.color_format->answer, "hsv") == 0) {
-            colorFormat = HSV;
-        }
-        else {
-            colorFormat = HEX;
-        }
+        colorFormat = G_option_to_color_format(opt.color_format);
     }
 
     if (flag.i->answer) {

--- a/raster/r.what.color/r.what.color.md
+++ b/raster/r.what.color/r.what.color.md
@@ -37,7 +37,7 @@ as an integer (no decimal point), otherwise it will be written in
 floating point format (*printf("%.15g")* format).
 
 If the lookup fails for a value, the color will be output as an
-asterisk, e.g.:
+asterisk (or as `null` in JSON), e.g.:
 
 ```sh
 r.what.color input=elevation.dem value=9999
@@ -52,13 +52,13 @@ r.what.color input=elevation.dem value=9999 format=json
 [
     {
         "value": 9999,
-        "color": "*"
+        "color": null
     }
 ]
 ```
 
 If a value cannot be parsed, both the value and the color will be output
-as an asterisk, e.g.:
+as an asterisk (or as `null` in JSON), e.g.:
 
 ```sh
 r.what.color input=elevation.dem value=bogus
@@ -72,8 +72,8 @@ r.what.color input=elevation.dem value=bogus format=plain
 r.what.color input=elevation.dem value=bogus format=json
 [
     {
-        "value": "*",
-        "color": "*"
+        "value": null,
+        "color": null
     }
 ]
 ```

--- a/raster/r.what.color/r.what.color.md
+++ b/raster/r.what.color/r.what.color.md
@@ -3,17 +3,34 @@
 *r.what.color* outputs the color associated with user-specified category
 values in a raster input map.
 
-Values may be specified either using the **values=** option, or by
+Values may be specified either using the **value=** option, or by
 specifying the **-i** flag and passing the values on `stdin`, one per
 line.
 
-For each value which is specified, a line of output will be generated
-consisting of the category value followed by the color, e.g.:
+For each specified value, an output will be generated consisting of the
+category value along with the color, e.g.:
 
 ```sh
 r.what.color input=elevation.dem value=1500
 1500: 223:127:31
+
+# In plain format using the triplet color format:
+r.what.color input=elevation.dem value=1500 format=plain color_format=triplet
+1500: 223:127:31
+
+# In JSON format using the triplet color format:
+r.what.color input=elevation.dem value=1500 format=json color_format=triplet
+[
+    {
+        "value": 1500,
+        "color": "223:127:31"
+    }
+]
 ```
+
+Similarly, other `color_format` options available with `format=json` and
+`format=plain` are `hex`, `hsv`, `triplet`, and `rgb`, with `hex` being the
+default color format.
 
 If the input map is an integer (CELL) map, the category will be written
 as an integer (no decimal point), otherwise it will be written in
@@ -25,6 +42,19 @@ asterisk, e.g.:
 ```sh
 r.what.color input=elevation.dem value=9999
 9999: *
+
+# In plain format:
+r.what.color input=elevation.dem value=9999 format=plain
+9999: *
+
+# In JSON format:
+r.what.color input=elevation.dem value=9999 format=json
+[
+    {
+        "value": 9999,
+        "color": "*"
+    }
+]
 ```
 
 If a value cannot be parsed, both the value and the color will be output
@@ -33,6 +63,19 @@ as an asterisk, e.g.:
 ```sh
 r.what.color input=elevation.dem value=bogus
 *: *
+
+# In plain format:
+r.what.color input=elevation.dem value=bogus format=plain
+*: *
+
+# In JSON format:
+r.what.color input=elevation.dem value=bogus format=json
+[
+    {
+        "value": "*",
+        "color": "*"
+    }
+]
 ```
 
 The format can be changed using the **format=** option. The value should
@@ -56,6 +99,39 @@ Common formats:
 
 - Tcl/Tk: `format="#%02x%02x%02x"`
 - WxPython: `format='"#%02x%02x%02x"'` or `format='"(%d,%d,%d)"'`
+
+NOTE:
+
+Please note that the *printf()*-style output format is deprecated and will be
+removed in a future release. Use the `color_format` option instead,
+together with `format=plain` or `format=json`.
+
+## Using r.what.color JSON output with python
+
+Print color associated with user-specified category value in JSON format using
+Python:
+
+```python
+import grass.script as gs
+
+# Run the r.what.color command with rgb option for JSON output format
+items = gs.parse_command(
+    "r.what.color",
+    input="elevation",
+    value=[100, 135, 156],
+    format="json",
+    color_format="rgb",
+)
+
+for item in items:
+    print(f"{item['value']}: {item['color']}")
+```
+
+```text
+100: rgb(255, 229, 0)
+135: rgb(195, 127, 59)
+156: rgb(23, 22, 21)
+```
 
 ## SEE ALSO
 

--- a/raster/r.what.color/testsuite/test_r_what_color.py
+++ b/raster/r.what.color/testsuite/test_r_what_color.py
@@ -197,12 +197,12 @@ class TestRWhatColor(TestCase):
         self.assertModule(module)
         result = json.loads(module.outputs.stdout)
         expected = [
-            {"color": "*", "value": 50},
+            {"color": None, "value": 50},
             {"color": "255:229:0", "value": 100},
             {"color": "255:128:0", "value": 116.029},
             {"color": "195:127:59", "value": 135},
             {"color": "23:22:21", "value": 156},
-            {"color": "*", "value": "*"},
+            {"color": None, "value": None},
         ]
 
         self.assertListEqual(
@@ -224,12 +224,12 @@ class TestRWhatColor(TestCase):
         self.assertModule(module)
         result = json.loads(module.outputs.stdout)
         expected = [
-            {"color": "*", "value": 50},
+            {"color": None, "value": 50},
             {"color": "rgb(255, 229, 0)", "value": 100},
             {"color": "rgb(255, 128, 0)", "value": 116.029},
             {"color": "rgb(195, 127, 59)", "value": 135},
             {"color": "rgb(23, 22, 21)", "value": 156},
-            {"color": "*", "value": "*"},
+            {"color": None, "value": None},
         ]
 
         self.assertListEqual(
@@ -251,12 +251,12 @@ class TestRWhatColor(TestCase):
         self.assertModule(module)
         result = json.loads(module.outputs.stdout)
         expected = [
-            {"color": "*", "value": 50},
+            {"color": None, "value": 50},
             {"color": "#FFE500", "value": 100},
             {"color": "#FF8000", "value": 116.029},
             {"color": "#C37F3B", "value": 135},
             {"color": "#171615", "value": 156},
-            {"color": "*", "value": "*"},
+            {"color": None, "value": None},
         ]
         self.assertListEqual(
             result,
@@ -293,12 +293,12 @@ class TestRWhatColor(TestCase):
         self.assertModule(module)
         result = json.loads(module.outputs.stdout)
         expected = [
-            {"color": "*", "value": 50},
+            {"color": None, "value": 50},
             {"color": "hsv(53, 100, 100)", "value": 100},
             {"color": "hsv(30, 100, 100)", "value": 116.029},
             {"color": "hsv(30, 69, 76)", "value": 135},
             {"color": "hsv(30, 8, 9)", "value": 156},
-            {"color": "*", "value": "*"},
+            {"color": None, "value": None},
         ]
 
         self.assertListEqual(

--- a/raster/r.what.color/testsuite/test_r_what_color.py
+++ b/raster/r.what.color/testsuite/test_r_what_color.py
@@ -1,6 +1,8 @@
 from grass.gunittest.case import TestCase
 from grass.gunittest.gmodules import SimpleModule
 
+import json
+
 
 class TestRWhatColor(TestCase):
     input = "elevation"
@@ -15,8 +17,8 @@ class TestRWhatColor(TestCase):
     def tearDownClass(cls):
         cls.del_temp_region()
 
-    def test_r_what_color_plain(self):
-        """Test r.what.color command for plain output format."""
+    def test_r_what_color_default(self):
+        """Test r.what.color command for default behavior."""
         module = SimpleModule(
             "r.what.color", input=self.input, flags="i", stdin=self.value
         )
@@ -31,10 +33,10 @@ class TestRWhatColor(TestCase):
             "*: *",
         ]
 
-        self.assertListEqual(result, expected, "Mismatch in printed output (plain)")
+        self.assertListEqual(result, expected, "Mismatch in printed output")
 
-    def test_r_what_color_plain_with_format_option(self):
-        """Test the r.what.color command with the format option for plain text output."""
+    def test_r_what_color_with_format_option(self):
+        """Test the r.what.color command with the format option (printf-style)."""
         module = SimpleModule(
             "r.what.color",
             input=self.input,
@@ -56,7 +58,253 @@ class TestRWhatColor(TestCase):
         self.assertListEqual(
             result,
             expected,
-            "Mismatch in printed output (plain) with the format option",
+            "Mismatch in printed output (printf-style) with the format option",
+        )
+
+    def test_r_what_color_plain_with_triplet_option(self):
+        """Test r.what.color command with triplet option for plain output format."""
+        module = SimpleModule(
+            "r.what.color",
+            input=self.input,
+            flags="i",
+            stdin=self.value,
+            format="plain",
+            color_format="triplet",
+        )
+        self.assertModule(module)
+        result = module.outputs.stdout.splitlines()
+        expected = [
+            "50: *",
+            "100: 255:229:0",
+            "116.029: 255:128:0",
+            "135: 195:127:59",
+            "156: 23:22:21",
+            "*: *",
+        ]
+
+        self.assertListEqual(
+            result,
+            expected,
+            "Mismatch in printed output (plain) with the triplet option",
+        )
+
+    def test_r_what_color_plain_with_rgb_option(self):
+        """Test r.what.color command with rgb option for plain output format."""
+        module = SimpleModule(
+            "r.what.color",
+            input=self.input,
+            flags="i",
+            stdin=self.value,
+            format="plain",
+            color_format="rgb",
+        )
+        self.assertModule(module)
+        result = module.outputs.stdout.splitlines()
+        expected = [
+            "50: *",
+            "100: rgb(255, 229, 0)",
+            "116.029: rgb(255, 128, 0)",
+            "135: rgb(195, 127, 59)",
+            "156: rgb(23, 22, 21)",
+            "*: *",
+        ]
+
+        self.assertListEqual(
+            result,
+            expected,
+            "Mismatch in printed output (plain) with the rgb option",
+        )
+
+    def test_r_what_color_plain_with_hex_option(self):
+        """Test r.what.color command with hex option for plain output format."""
+        module = SimpleModule(
+            "r.what.color",
+            input=self.input,
+            flags="i",
+            stdin=self.value,
+            format="plain",
+            color_format="hex",
+        )
+        self.assertModule(module)
+        result = module.outputs.stdout.splitlines()
+        expected = [
+            "50: *",
+            "100: #FFE500",
+            "116.029: #FF8000",
+            "135: #C37F3B",
+            "156: #171615",
+            "*: *",
+        ]
+        self.assertListEqual(
+            result,
+            expected,
+            "Mismatch in printed output (plain) with the hex option",
+        )
+
+        # Test r.what.color command with default color_format option for plain output format
+        module = SimpleModule(
+            "r.what.color",
+            input=self.input,
+            flags="i",
+            stdin=self.value,
+            format="plain",
+        )
+        self.assertModule(module)
+        result = module.outputs.stdout.splitlines()
+        self.assertListEqual(
+            result,
+            expected,
+            "Mismatch in printed output (plain) with the default option",
+        )
+
+    def test_r_what_color_plain_with_hsv_option(self):
+        """Test r.what.color command with hsv option for plain output format."""
+        module = SimpleModule(
+            "r.what.color",
+            input=self.input,
+            flags="i",
+            stdin=self.value,
+            format="plain",
+            color_format="hsv",
+        )
+        self.assertModule(module)
+        result = module.outputs.stdout.splitlines()
+        expected = [
+            "50: *",
+            "100: hsv(53, 100, 100)",
+            "116.029: hsv(30, 100, 100)",
+            "135: hsv(30, 69, 76)",
+            "156: hsv(30, 8, 9)",
+            "*: *",
+        ]
+
+        self.assertListEqual(
+            result,
+            expected,
+            "Mismatch in printed output (plain) with the hsv option",
+        )
+
+    def test_r_what_color_json_with_triplet_option(self):
+        """Test r.what.color command with triplet option for json output format."""
+        module = SimpleModule(
+            "r.what.color",
+            input=self.input,
+            flags="i",
+            stdin=self.value,
+            format="json",
+            color_format="triplet",
+        )
+        self.assertModule(module)
+        result = json.loads(module.outputs.stdout)
+        expected = [
+            {"color": "*", "value": 50},
+            {"color": "255:229:0", "value": 100},
+            {"color": "255:128:0", "value": 116.029},
+            {"color": "195:127:59", "value": 135},
+            {"color": "23:22:21", "value": 156},
+            {"color": "*", "value": "*"},
+        ]
+
+        self.assertListEqual(
+            result,
+            expected,
+            "Mismatch in printed output (JSON) with the triplet option",
+        )
+
+    def test_r_what_color_json_with_rgb_option(self):
+        """Test r.what.color command with rgb option for json output format."""
+        module = SimpleModule(
+            "r.what.color",
+            input=self.input,
+            flags="i",
+            stdin=self.value,
+            format="json",
+            color_format="rgb",
+        )
+        self.assertModule(module)
+        result = json.loads(module.outputs.stdout)
+        expected = [
+            {"color": "*", "value": 50},
+            {"color": "rgb(255, 229, 0)", "value": 100},
+            {"color": "rgb(255, 128, 0)", "value": 116.029},
+            {"color": "rgb(195, 127, 59)", "value": 135},
+            {"color": "rgb(23, 22, 21)", "value": 156},
+            {"color": "*", "value": "*"},
+        ]
+
+        self.assertListEqual(
+            result,
+            expected,
+            "Mismatch in printed output (JSON) with the rgb option",
+        )
+
+    def test_r_what_color_json_with_hex_option(self):
+        """Test r.what.color command with hex option for json output format."""
+        module = SimpleModule(
+            "r.what.color",
+            input=self.input,
+            flags="i",
+            stdin=self.value,
+            format="json",
+            color_format="hex",
+        )
+        self.assertModule(module)
+        result = json.loads(module.outputs.stdout)
+        expected = [
+            {"color": "*", "value": 50},
+            {"color": "#FFE500", "value": 100},
+            {"color": "#FF8000", "value": 116.029},
+            {"color": "#C37F3B", "value": 135},
+            {"color": "#171615", "value": 156},
+            {"color": "*", "value": "*"},
+        ]
+        self.assertListEqual(
+            result,
+            expected,
+            "Mismatch in printed output (JSON) with the hex option",
+        )
+
+        # Test r.what.color command with default color_format option for json output format
+        module = SimpleModule(
+            "r.what.color",
+            input=self.input,
+            flags="i",
+            stdin=self.value,
+            format="json",
+        )
+        self.assertModule(module)
+        result = json.loads(module.outputs.stdout)
+        self.assertListEqual(
+            result,
+            expected,
+            "Mismatch in printed output (JSON) with the default option",
+        )
+
+    def test_r_what_color_json_with_hsv_option(self):
+        """Test r.what.color command with hsv option for json output format."""
+        module = SimpleModule(
+            "r.what.color",
+            input=self.input,
+            flags="i",
+            stdin=self.value,
+            format="json",
+            color_format="hsv",
+        )
+        self.assertModule(module)
+        result = json.loads(module.outputs.stdout)
+        expected = [
+            {"color": "*", "value": 50},
+            {"color": "hsv(53, 100, 100)", "value": 100},
+            {"color": "hsv(30, 100, 100)", "value": 116.029},
+            {"color": "hsv(30, 69, 76)", "value": 135},
+            {"color": "hsv(30, 8, 9)", "value": 156},
+            {"color": "*", "value": "*"},
+        ]
+
+        self.assertListEqual(
+            result,
+            expected,
+            "Mismatch in printed output (JSON) with the hsv option",
         )
 
 

--- a/vector/v.colors.out/main.c
+++ b/vector/v.colors.out/main.c
@@ -115,18 +115,7 @@ int main(int argc, char **argv)
         colors = &cat_colors;
 
     if (strcmp(opt.format->answer, "json") == 0) {
-        if (strcmp(opt.color_format->answer, "rgb") == 0) {
-            clr_frmt = RGB;
-        }
-        else if (strcmp(opt.color_format->answer, "triplet") == 0) {
-            clr_frmt = TRIPLET;
-        }
-        else if (strcmp(opt.color_format->answer, "hsv") == 0) {
-            clr_frmt = HSV;
-        }
-        else {
-            clr_frmt = HEX;
-        }
+        clr_frmt = G_option_to_color_format(opt.color_format);
         Rast_print_json_colors(colors, (DCELL)min, (DCELL)max, fp,
                                flag.p->answer ? 1 : 0, clr_frmt);
     }


### PR DESCRIPTION
This PR adds JSON support to the `r.what.color` module. The JSON output looks like:

```json
[
    {"color": "*", "value": 50},
    {"color": "255:229:0", "value": 100},
    {"color": "255:128:0", "value": 116.029},
    {"color": "195:127:59", "value": 135},
    {"color": "23:22:21", "value": 156},
    {"color": "*", "value": "*"}
]
```

This PR includes the following changes:

1. Adds JSON support to `r.what.color` by extending the `format` option to accept either `plain` or `json` as output formats.
2. Introduces the `color_format` option to specify the color format in JSON or plain output. Supported values are `hex`, `hsv`, `triplet`, and `rgb`, with `hex` as the default.
3. Adds corresponding tests for the change.
4. Updates the documentation to include a JSON output example and a Python example demonstrating JSON parsing.