### PR TITLE
i.group: add json support

### DIFF
--- a/imagery/CMakeLists.txt
+++ b/imagery/CMakeLists.txt
@@ -138,7 +138,7 @@ build_program_in_subdir(
   ${LIBM})
 
 build_program_in_subdir(i.group DEPENDS grass_imagery grass_raster grass_vector
-                        grass_gis)
+                        grass_gis grass_parson)
 
 build_program_in_subdir(i.his.rgb DEPENDS grass_imagery grass_raster
                         grass_vector grass_gis)

--- a/imagery/i.group/Makefile
+++ b/imagery/i.group/Makefile
@@ -2,7 +2,7 @@ MODULE_TOPDIR = ../..
 
 PGM = i.group
 
-LIBES = $(IMAGERYLIB) $(GISLIB)
+LIBES = $(IMAGERYLIB) $(GISLIB) $(PARSONLIB)
 DEPENDENCIES = $(IMAGERYDEP) $(GISDEP)
 
 include $(MODULE_TOPDIR)/include/Make/Module.make

--- a/imagery/i.group/i.group.md
+++ b/imagery/i.group/i.group.md
@@ -29,6 +29,68 @@ only the visible light bands of Landsat-7:
 i.group group=vis_bands subgroup=vis_bands input=lsat7_2000_10,lsat7_2000_20,lsat7_2000_30
 ```
 
+To list files in the `vis_bands` subgroup under the `vis_bands` group:
+
+```sh
+# In shell format
+i.group group=vis_bands subgroup=vis_bands -l format=shell
+lsat7_2000_10@PERMANENT
+lsat7_2000_20@PERMANENT
+lsat7_2000_30@PERMANENT
+
+# In JSON format
+i.group group=vis_bands subgroup=vis_bands -l format=json
+{
+    "group": "vis_bands",
+    "subgroup": "vis_bands",
+    "maps": [
+        "lsat7_2000_10@PERMANENT",
+        "lsat7_2000_20@PERMANENT",
+        "lsat7_2000_30@PERMANENT"
+    ]
+}
+```
+
+To list maps in the `vis_bands` group using Python:
+
+```python
+import grass.script as gs
+
+# Run i.group with JSON output and the -l flag
+data = gs.parse_command(
+    "i.group",
+    group="vis_bands",
+    flags="l",
+    format="json",
+)
+
+for item in data["maps"]:
+    print(item)
+```
+
+```text
+lsat7_2000_10@PERMANENT
+lsat7_2000_20@PERMANENT
+lsat7_2000_30@PERMANENT
+```
+
+To list subgroups in the `vis_bands` group:
+
+```sh
+# In shell format
+i.group group=vis_bands -s format=shell
+vis_bands
+
+# In JSON format
+i.group group=vis_bands -s format=json
+{
+    "group": "vis_bands",
+    "subgroups": [
+        "vis_bands"
+    ]
+}
+```
+
 ## SEE ALSO
 
 The GRASS 4 *[Image Processing

--- a/imagery/i.group/main.c
+++ b/imagery/i.group/main.c
@@ -23,6 +23,9 @@
 #include <grass/gis.h>
 #include <grass/imagery.h>
 #include <grass/glocale.h>
+#include <grass/parson.h>
+
+enum OutputFormat { PLAIN, JSON, SHELL };
 
 /* function prototypes */
 static int add_or_update_group(char group[INAME_LEN], char **rasters, int k);
@@ -33,7 +36,9 @@ static int remove_group_files(char group[INAME_LEN], char **rasters, int k);
 static int remove_subgroup_files(char group[INAME_LEN],
                                  char subgroup[INAME_LEN], char **rasters,
                                  int k);
-static void print_subgroups(const char *group, const char *mapset, int simple);
+static void print_subgroups(const char *group, const char *mapset,
+                            enum OutputFormat format, JSON_Object *root_object);
+static int list_group_json(const struct Ref *ref, JSON_Object *root_object);
 
 int main(int argc, char *argv[])
 {
@@ -43,9 +48,14 @@ int main(int argc, char *argv[])
     int m, k = 0;
     int can_edit;
 
-    struct Option *grp, *rast, *rastf, *sgrp;
+    struct Option *grp, *rast, *rastf, *sgrp, *frmt;
     struct Flag *r, *l, *s, *simple_flag;
     struct GModule *module;
+
+    enum OutputFormat format;
+
+    JSON_Value *root_value = NULL;
+    JSON_Object *root_object = NULL;
 
     G_gisinit(argv[0]);
 
@@ -73,6 +83,13 @@ int main(int argc, char *argv[])
     rastf->description = _("Input file with one raster map name per line");
     rastf->required = NO;
 
+    frmt = G_define_standard_option(G_OPT_F_FORMAT);
+    frmt->options = "plain,shell,json";
+    frmt->descriptions = _("plain;Human readable text output;"
+                           "shell;shell script style text output;"
+                           "json;JSON (JavaScript Object Notation);");
+    frmt->guisection = _("Print");
+
     r = G_define_flag();
     r->key = 'r';
     r->description =
@@ -91,16 +108,47 @@ int main(int argc, char *argv[])
 
     simple_flag = G_define_flag();
     simple_flag->key = 'g';
-    simple_flag->description = _("Print in shell script style");
+    simple_flag->label = _("Print in shell script style [deprecated]");
+    simple_flag->description = _(
+        "This flag is deprecated and will be removed in a future release. Use "
+        "format=shell instead.");
     simple_flag->guisection = _("Print");
 
     if (G_parser(argc, argv))
         exit(EXIT_FAILURE);
 
+    if (strcmp(frmt->answer, "json") == 0) {
+        format = JSON;
+        root_value = json_value_init_object();
+        if (root_value == NULL) {
+            G_fatal_error(
+                _("Failed to initialize JSON object. Out of memory?"));
+        }
+        root_object = json_object(root_value);
+    }
+    else if (strcmp(frmt->answer, "shell") == 0) {
+        format = SHELL;
+    }
+    else {
+        format = PLAIN;
+    }
+
+    if (simple_flag->answer) {
+        G_verbose_message(
+            _("Flag 'g' is deprecated and will be removed in a future "
+              "release. Please use format=shell instead."));
+        if (format == JSON) {
+            json_value_free(root_value);
+            G_fatal_error(_("Cannot use the -g flag with format=json; "
+                            "please select only one option."));
+        }
+        format = SHELL;
+    }
+
     /* backward compatibility -> simple list implied l flag list, if there was
-       only l flag (with s flag added it is not clear, simple_flag is linked to
-       both) */
-    if ((simple_flag->answer && !s->answer) && !l->answer)
+       only l flag (with s flag added it is not clear, shell/json format is
+       linked to both) */
+    if (format != PLAIN && !s->answer && !l->answer)
         l->answer = TRUE;
 
     /* Determine number of raster maps to include */
@@ -182,29 +230,45 @@ int main(int argc, char *argv[])
             if (sgrp->answer) {
                 /* list subgroup files */
                 I_get_subgroup_ref2(group, sgrp->answer, mapset, &ref);
-                if (simple_flag->answer) {
+                switch (format) {
+                case SHELL:
                     G_message(_("Subgroup <%s> of group <%s> references the "
                                 "following raster maps:"),
                               sgrp->answer, group);
                     I_list_subgroup_simple(&ref, stdout);
-                }
-                else
+                    break;
+                case PLAIN:
                     I_list_subgroup(group, sgrp->answer, &ref, stdout);
+                    break;
+                case JSON:
+                    json_object_set_string(root_object, "group", group);
+                    json_object_set_string(root_object, "subgroup",
+                                           sgrp->answer);
+                    list_group_json(&ref, root_object);
+                    break;
+                }
             }
             else if (s->answer) {
-                print_subgroups(group, mapset, simple_flag->answer);
+                print_subgroups(group, mapset, format, root_object);
             }
             else {
                 /* list group files */
                 I_get_group_ref2(group, mapset, &ref);
-                if (simple_flag->answer) {
+                switch (format) {
+                case SHELL:
                     G_message(
                         _("Group <%s> references the following raster maps:"),
                         group);
                     I_list_group_simple(&ref, stdout);
-                }
-                else
+                    break;
+                case PLAIN:
                     I_list_group(group, &ref, stdout);
+                    break;
+                case JSON:
+                    json_object_set_string(root_object, "group", group);
+                    list_group_json(&ref, root_object);
+                    break;
+                }
             }
         }
         else {
@@ -233,6 +297,17 @@ int main(int argc, char *argv[])
                 add_or_update_group(group, rasters, k);
             }
         }
+    }
+
+    if (format == JSON) {
+        char *serialized_string = NULL;
+        serialized_string = json_serialize_to_string_pretty(root_value);
+        if (serialized_string == NULL) {
+            G_fatal_error(_("Failed to initialize pretty JSON string."));
+        }
+        puts(serialized_string);
+        json_free_serialized_string(serialized_string);
+        json_value_free(root_value);
     }
 
     return EXIT_SUCCESS;
@@ -435,18 +510,31 @@ static int remove_subgroup_files(char group[INAME_LEN],
     return 0;
 }
 
-static void print_subgroups(const char *group, const char *mapset, int simple)
+static void print_subgroups(const char *group, const char *mapset,
+                            enum OutputFormat format, JSON_Object *root_object)
 {
     int subgs_num, i;
     int len, tot_len;
     int max;
     char **subgs;
+    JSON_Value *list_value = NULL;
+    JSON_Array *list_array = NULL;
+
+    if (format == JSON) {
+        list_value = json_value_init_array();
+        if (list_value == NULL) {
+            G_fatal_error(_("Failed to initialize JSON array. Out of memory?"));
+        }
+        list_array = json_array(list_value);
+    }
 
     subgs = I_list_subgroups2(group, mapset, &subgs_num);
-    if (simple)
+    switch (format) {
+    case SHELL:
         for (i = 0; i < subgs_num; i++)
             fprintf(stdout, "%s\n", subgs[i]);
-    else {
+        break;
+    case PLAIN:
         if (subgs_num <= 0) {
             fprintf(stdout, _("Group <%s> does not contain any subgroup.\n"),
                     group);
@@ -474,7 +562,46 @@ static void print_subgroups(const char *group, const char *mapset, int simple)
         if (tot_len)
             fprintf(stdout, "\n");
         fprintf(stdout, "-------------\n");
+        break;
+    case JSON:
+        json_object_set_string(root_object, "group", group);
+        for (i = 0; i < subgs_num; i++)
+            json_array_append_string(list_array, subgs[i]);
+
+        json_object_set_value(root_object, "subgroups", list_value);
+        break;
     }
     G_free(subgs);
     return;
+}
+
+/*!
+ * \brief List maps in a group (JSON)
+ *
+ * List map in map@mapset form.
+ *
+ * \param ref group reference (set with I_get_group_ref())
+ * \param root_object where to append JSON
+ * \return 0
+ */
+static int list_group_json(const struct Ref *ref, JSON_Object *root_object)
+{
+    int i;
+    char map_str[1024];
+
+    JSON_Value *list_value = json_value_init_array();
+    if (list_value == NULL) {
+        G_fatal_error(_("Failed to initialize JSON array. Out of memory?"));
+    }
+    JSON_Array *list_array = json_array(list_value);
+
+    for (i = 0; i < ref->nfiles; i++) {
+        snprintf(map_str, sizeof(map_str), "%s@%s", ref->file[i].name,
+                 ref->file[i].mapset);
+        json_array_append_string(list_array, map_str);
+    }
+
+    json_object_set_value(root_object, "maps", list_value);
+
+    return 0;
 }

--- a/imagery/i.group/main.c
+++ b/imagery/i.group/main.c
@@ -38,7 +38,7 @@ static int remove_subgroup_files(char group[INAME_LEN],
                                  int k);
 static void print_subgroups(const char *group, const char *mapset,
                             enum OutputFormat format, JSON_Object *root_object);
-static int list_group_json(const struct Ref *ref, JSON_Object *root_object);
+static void list_files_json(const struct Ref *ref, JSON_Object *root_object);
 
 int main(int argc, char *argv[])
 {
@@ -244,7 +244,7 @@ int main(int argc, char *argv[])
                     json_object_set_string(root_object, "group", group);
                     json_object_set_string(root_object, "subgroup",
                                            sgrp->answer);
-                    list_group_json(&ref, root_object);
+                    list_files_json(&ref, root_object);
                     break;
                 }
             }
@@ -266,7 +266,7 @@ int main(int argc, char *argv[])
                     break;
                 case JSON:
                     json_object_set_string(root_object, "group", group);
-                    list_group_json(&ref, root_object);
+                    list_files_json(&ref, root_object);
                     break;
                 }
             }
@@ -576,15 +576,14 @@ static void print_subgroups(const char *group, const char *mapset,
 }
 
 /*!
- * \brief List maps in a group (JSON)
+ * \brief List files in a (sub)group (JSON)
  *
  * List map in map@mapset form.
  *
  * \param ref group reference (set with I_get_group_ref())
- * \param root_object where to append JSON
- * \return 0
+ * \param root_object JSON object to which data will be appended.
  */
-static int list_group_json(const struct Ref *ref, JSON_Object *root_object)
+static void list_files_json(const struct Ref *ref, JSON_Object *root_object)
 {
     int i;
     char map_str[1024];
@@ -602,6 +601,4 @@ static int list_group_json(const struct Ref *ref, JSON_Object *root_object)
     }
 
     json_object_set_value(root_object, "maps", list_value);
-
-    return 0;
 }

--- a/imagery/i.group/testsuite/test_i_group.py
+++ b/imagery/i.group/testsuite/test_i_group.py
@@ -58,6 +58,9 @@ class TestIGroup(TestCase):
         self.assertIn("raster2", groups)
         self.assertIn("raster3", groups)
 
+        groups_shell = gs.read_command("i.group", group=self.test_group, format="shell")
+        self.assertEqual(groups_shell, groups)
+
         self.assertModule(
             "i.group",
             group=self.test_group,
@@ -66,6 +69,9 @@ class TestIGroup(TestCase):
         )
         groups = gs.read_command("i.group", group=self.test_group, flags="g")
         self.assertNotIn("raster2", groups)
+
+        groups_shell = gs.read_command("i.group", group=self.test_group, format="shell")
+        self.assertEqual(groups_shell, groups)
 
     def test_subgroup_handling(self):
         """Test subgroup creation and listing of subgroup members.(-s flag)"""
@@ -94,6 +100,182 @@ class TestIGroup(TestCase):
         self.assertNotIn("raster1", subgroup2)
         self.assertNotIn("raster2", subgroup2)
         self.assertIn("raster3", subgroup2)
+
+    def test_list_files_shell(self):
+        """Test listing of (sub)group files in shell format."""
+        self.assertModule(
+            "i.group",
+            group=self.test_group,
+            subgroup=self.test_subgroup1,
+            input="raster1,raster2",
+        )
+        self.assertModule(
+            "i.group",
+            group=self.test_group,
+            subgroup=self.test_subgroup2,
+            input="raster3",
+        )
+
+        # Test listing of test_subgroup1 files in shell format.
+        subgroup = gs.read_command(
+            "i.group",
+            group=self.test_group,
+            subgroup=self.test_subgroup1,
+            flags="l",
+            format="shell",
+        ).splitlines()
+
+        expected_subgroup = ["raster1@PERMANENT", "raster2@PERMANENT"]
+        self.assertEqual(subgroup, expected_subgroup)
+
+        # Test listing of test_subgroup2 files in shell format.
+        subgroup = gs.read_command(
+            "i.group",
+            group=self.test_group,
+            subgroup=self.test_subgroup2,
+            flags="l",
+            format="shell",
+        ).splitlines()
+
+        expected_subgroup = ["raster3@PERMANENT"]
+        self.assertEqual(subgroup, expected_subgroup)
+
+        # Test listing of group files in shell format.
+        group = gs.read_command(
+            "i.group",
+            group=self.test_group,
+            flags="l",
+            format="shell",
+        ).splitlines()
+
+        expected_group = ["raster1@PERMANENT", "raster2@PERMANENT", "raster3@PERMANENT"]
+        self.assertEqual(group, expected_group)
+
+    def test_list_files_json(self):
+        """Test listing of (sub)group files in json format."""
+        self.assertModule(
+            "i.group",
+            group=self.test_group,
+            subgroup=self.test_subgroup1,
+            input="raster1,raster2",
+        )
+        self.assertModule(
+            "i.group",
+            group=self.test_group,
+            subgroup=self.test_subgroup2,
+            input="raster3",
+        )
+
+        # Test listing of test_subgroup_1 files in json format.
+        subgroup = gs.parse_command(
+            "i.group",
+            group=self.test_group,
+            subgroup=self.test_subgroup1,
+            flags="l",
+            format="json",
+        )
+
+        expected_subgroup = {
+            "group": "test_group",
+            "subgroup": "test_subgroup_1",
+            "maps": [
+                "raster1@PERMANENT",
+                "raster2@PERMANENT",
+            ],
+        }
+        self.assertEqual(subgroup, expected_subgroup)
+
+        # Test listing of test_subgroup2 files in json format.
+        subgroup = gs.parse_command(
+            "i.group",
+            group=self.test_group,
+            subgroup=self.test_subgroup2,
+            flags="l",
+            format="json",
+        )
+
+        expected_subgroup = {
+            "group": "test_group",
+            "subgroup": "test_subgroup_2",
+            "maps": [
+                "raster3@PERMANENT",
+            ],
+        }
+        self.assertEqual(subgroup, expected_subgroup)
+
+        # Test listing of group files in json format.
+        group = gs.parse_command(
+            "i.group",
+            group=self.test_group,
+            flags="l",
+            format="json",
+        )
+
+        expected_group = {
+            "group": "test_group",
+            "maps": [
+                "raster1@PERMANENT",
+                "raster2@PERMANENT",
+                "raster3@PERMANENT",
+            ],
+        }
+        self.assertEqual(group, expected_group)
+
+    def test_list_subgroups_shell(self):
+        """Test listing of subgroups in group using shell format."""
+        self.assertModule(
+            "i.group",
+            group=self.test_group,
+            subgroup=self.test_subgroup1,
+            input="raster1,raster2",
+        )
+        self.assertModule(
+            "i.group",
+            group=self.test_group,
+            subgroup=self.test_subgroup2,
+            input="raster3",
+        )
+
+        subgroups = gs.read_command(
+            "i.group",
+            group=self.test_group,
+            flags="s",
+            format="shell",
+        ).splitlines()
+
+        expected_subgroups = ["test_subgroup_1", "test_subgroup_2"]
+        self.assertEqual(subgroups, expected_subgroups)
+
+    def test_list_subgroups_json(self):
+        """Test listing of subgroups in group using json format."""
+        self.assertModule(
+            "i.group",
+            group=self.test_group,
+            subgroup=self.test_subgroup1,
+            input="raster1,raster2",
+        )
+        self.assertModule(
+            "i.group",
+            group=self.test_group,
+            subgroup=self.test_subgroup2,
+            input="raster3",
+        )
+
+        subgroups = gs.parse_command(
+            "i.group",
+            group=self.test_group,
+            flags="s",
+            format="json",
+        )
+
+        expected_subgroups = {
+            "group": "test_group",
+            "subgroups": [
+                "test_subgroup_1",
+                "test_subgroup_2",
+            ],
+        }
+        self.assertEqual(subgroups, expected_subgroups)
 
 
 if __name__ == "__main__":

--- a/imagery/i.group/testsuite/test_i_group.py
+++ b/imagery/i.group/testsuite/test_i_group.py
@@ -123,10 +123,11 @@ class TestIGroup(TestCase):
             subgroup=self.test_subgroup1,
             flags="l",
             format="shell",
-        ).splitlines()
+        )
 
-        expected_subgroup = ["raster1@PERMANENT", "raster2@PERMANENT"]
-        self.assertEqual(subgroup, expected_subgroup)
+        self.assertIn("raster1", subgroup)
+        self.assertIn("raster2", subgroup)
+        self.assertNotIn("raster3", subgroup)
 
         # Test listing of test_subgroup2 files in shell format.
         subgroup = gs.read_command(
@@ -135,10 +136,11 @@ class TestIGroup(TestCase):
             subgroup=self.test_subgroup2,
             flags="l",
             format="shell",
-        ).splitlines()
+        )
 
-        expected_subgroup = ["raster3@PERMANENT"]
-        self.assertEqual(subgroup, expected_subgroup)
+        self.assertNotIn("raster1", subgroup)
+        self.assertNotIn("raster2", subgroup)
+        self.assertIn("raster3", subgroup)
 
         # Test listing of group files in shell format.
         group = gs.read_command(
@@ -146,10 +148,11 @@ class TestIGroup(TestCase):
             group=self.test_group,
             flags="l",
             format="shell",
-        ).splitlines()
+        )
 
-        expected_group = ["raster1@PERMANENT", "raster2@PERMANENT", "raster3@PERMANENT"]
-        self.assertEqual(group, expected_group)
+        self.assertIn("raster1", group)
+        self.assertIn("raster2", group)
+        self.assertIn("raster3", group)
 
     def test_list_files_json(self):
         """Test listing of (sub)group files in json format."""
@@ -175,15 +178,11 @@ class TestIGroup(TestCase):
             format="json",
         )
 
-        expected_subgroup = {
-            "group": "test_group",
-            "subgroup": "test_subgroup_1",
-            "maps": [
-                "raster1@PERMANENT",
-                "raster2@PERMANENT",
-            ],
-        }
-        self.assertEqual(subgroup, expected_subgroup)
+        self.assertEqual(subgroup["group"], self.test_group)
+        self.assertEqual(subgroup["subgroup"], self.test_subgroup1)
+        self.assertTrue(any("raster1" in m for m in subgroup["maps"]))
+        self.assertTrue(any("raster2" in m for m in subgroup["maps"]))
+        self.assertTrue(all("raster3" not in m for m in subgroup["maps"]))
 
         # Test listing of test_subgroup2 files in json format.
         subgroup = gs.parse_command(
@@ -201,7 +200,11 @@ class TestIGroup(TestCase):
                 "raster3@PERMANENT",
             ],
         }
-        self.assertEqual(subgroup, expected_subgroup)
+        self.assertEqual(subgroup["group"], self.test_group)
+        self.assertEqual(subgroup["subgroup"], self.test_subgroup2)
+        self.assertTrue(all("raster1" not in m for m in subgroup["maps"]))
+        self.assertTrue(all("raster2" not in m for m in subgroup["maps"]))
+        self.assertTrue(any("raster3" in m for m in subgroup["maps"]))
 
         # Test listing of group files in json format.
         group = gs.parse_command(
@@ -211,15 +214,10 @@ class TestIGroup(TestCase):
             format="json",
         )
 
-        expected_group = {
-            "group": "test_group",
-            "maps": [
-                "raster1@PERMANENT",
-                "raster2@PERMANENT",
-                "raster3@PERMANENT",
-            ],
-        }
-        self.assertEqual(group, expected_group)
+        self.assertEqual(group["group"], self.test_group)
+        self.assertTrue(any("raster1" in m for m in group["maps"]))
+        self.assertTrue(any("raster2" in m for m in group["maps"]))
+        self.assertTrue(any("raster3" in m for m in group["maps"]))
 
     def test_list_subgroups_shell(self):
         """Test listing of subgroups in group using shell format."""
@@ -241,10 +239,10 @@ class TestIGroup(TestCase):
             group=self.test_group,
             flags="s",
             format="shell",
-        ).splitlines()
+        )
 
-        expected_subgroups = ["test_subgroup_1", "test_subgroup_2"]
-        self.assertEqual(subgroups, expected_subgroups)
+        self.assertIn(self.test_subgroup1, subgroups)
+        self.assertIn(self.test_subgroup2, subgroups)
 
     def test_list_subgroups_json(self):
         """Test listing of subgroups in group using json format."""
@@ -268,14 +266,9 @@ class TestIGroup(TestCase):
             format="json",
         )
 
-        expected_subgroups = {
-            "group": "test_group",
-            "subgroups": [
-                "test_subgroup_1",
-                "test_subgroup_2",
-            ],
-        }
-        self.assertEqual(subgroups, expected_subgroups)
+        self.assertEqual(subgroups["group"], self.test_group)
+        self.assertTrue(any(self.test_subgroup1 in m for m in subgroups["subgroups"]))
+        self.assertTrue(any(self.test_subgroup2 in m for m in subgroups["subgroups"]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description

This PR adds JSON output support to the `i.group` module.

### Changes included

1. Adds a `format` option with `plain`, `shell`, and `json` modes for output formatting.
2. Adds tests covering each of the new formats.
3. Updates the documentation with a JSON output example and a Python example demonstrating JSON parsing.

### Output examples:

**With `-l` flag:**

```json
{
    "group": "vis_bands",
    "subgroup": "vis_bands",
    "maps": [
        "lsat7_2000_10@PERMANENT",
        "lsat7_2000_20@PERMANENT",
        "lsat7_2000_30@PERMANENT"
    ]
}
```

**With `-s` flag:**

```json
{
    "group": "vis_bands",
    "subgroups": [
        "vis_bands"
    ]
}
```