### PR TITLE
r.stats: add CSV and JSONL support

### DIFF
--- a/raster/r.stats/global.h
+++ b/raster/r.stats/global.h
@@ -6,7 +6,7 @@
 #define SORT_ASC     1
 #define SORT_DESC    2
 
-enum OutputFormat { PLAIN, JSON };
+enum OutputFormat { PLAIN, CSV, JSON };
 
 extern char *no_data_str;
 extern int nfiles;

--- a/raster/r.stats/global.h
+++ b/raster/r.stats/global.h
@@ -15,6 +15,7 @@ extern int ncols, no_nulls, no_nulls_all;
 extern int nsteps, cat_ranges, raw_output, as_int, averaged;
 extern int *is_fp;
 extern DCELL *DMAX, *DMIN;
+extern char **map_names; /* input map names */
 
 extern CELL NULL_CELL;
 

--- a/raster/r.stats/main.c
+++ b/raster/r.stats/main.c
@@ -40,6 +40,7 @@ CELL NULL_CELL;
 
 char *fs;
 struct Categories *labels;
+char **map_names; /* input map names */
 
 int main(int argc, char *argv[])
 {
@@ -325,8 +326,11 @@ int main(int argc, char *argv[])
         is_fp = (int *)G_realloc(is_fp, (nfiles + 1) * sizeof(int));
         DMAX = (DCELL *)G_realloc(DMAX, (nfiles + 1) * sizeof(DCELL));
         DMIN = (DCELL *)G_realloc(DMIN, (nfiles + 1) * sizeof(DCELL));
+        map_names =
+            (char **)G_realloc(map_names, (nfiles + 1) * sizeof(char *));
 
         fd[nfiles] = Rast_open_old(name, "");
+        map_names[nfiles] = G_store(name);
 
         if (!as_int)
             is_fp[nfiles] = Rast_map_is_fp(name, "");

--- a/raster/r.stats/main.c
+++ b/raster/r.stats/main.c
@@ -121,7 +121,7 @@ int main(int argc, char *argv[])
         _("Name for output file (if omitted or \"-\" output to stdout)");
 
     option.fs = G_define_standard_option(G_OPT_F_SEP);
-    option.fs->answer = "space";
+    option.fs->answer = NULL;
     option.fs->guisection = _("Formatting");
 
     option.nv = G_define_standard_option(G_OPT_M_NULL_VALUE);
@@ -152,6 +152,10 @@ int main(int argc, char *argv[])
     option.sort->guisection = _("Formatting");
 
     option.format = G_define_standard_option(G_OPT_F_FORMAT);
+    option.format->options = "plain,csv,json";
+    option.format->descriptions = ("plain;Human readable text output;"
+                                   "csv;CSV (Comma Separated Values);"
+                                   "json;JSON (JavaScript Object Notation);");
     option.format->guisection = _("Print");
 
     /* Define the different flags */
@@ -243,10 +247,21 @@ int main(int argc, char *argv[])
         nsteps = 255;
     }
 
+    /* For backward compatibility */
+    if (!option.fs->answer) {
+        if (strcmp(option.format->answer, "csv") == 0)
+            option.fs->answer = "comma";
+        else
+            option.fs->answer = "space";
+    }
+
     if (strcmp(option.format->answer, "json") == 0) {
         format = JSON;
         root_value = json_value_init_array();
         root_array = json_array(root_value);
+    }
+    else if (strcmp(option.format->answer, "csv") == 0) {
+        format = CSV;
     }
     else {
         format = PLAIN;

--- a/raster/r.stats/raw_stats.c
+++ b/raster/r.stats/raw_stats.c
@@ -48,9 +48,9 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels,
             fprintf(stdout, "%s%s%s%s", "col", fs, "row", fs);
 
         for (i = 0; i < nfiles; i++) {
-            fprintf(stdout, "%s%s", i ? fs : "", "cat");
+            fprintf(stdout, "%s%s_%s", i ? fs : "", map_names[i], "cat");
             if (with_labels)
-                fprintf(stdout, "%s%s", fs, "label");
+                fprintf(stdout, "%s%s_%s", fs, map_names[i], "label");
         }
         fprintf(stdout, "\n");
     }

--- a/raster/r.stats/raw_stats.c
+++ b/raster/r.stats/raw_stats.c
@@ -40,6 +40,21 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels,
     if (with_coordinates)
         G_get_set_window(&window);
 
+    if (format == CSV) {
+        /* CSV Header */
+        if (with_coordinates)
+            fprintf(stdout, "%s%s%s%s", "east", fs, "north", fs);
+        if (with_xy)
+            fprintf(stdout, "%s%s%s%s", "col", fs, "row", fs);
+
+        for (i = 0; i < nfiles; i++) {
+            fprintf(stdout, "%s%s", i ? fs : "", "cat");
+            if (with_labels)
+                fprintf(stdout, "%s%s", fs, "label");
+        }
+        fprintf(stdout, "\n");
+    }
+
     /* here we go */
     Rast_set_c_null_value(&null_cell, 1);
     for (row = 0; row < nrows; row++) {
@@ -96,6 +111,7 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels,
                     json_object_set_number(object, "row", row + 1);
                 }
                 break;
+            case CSV:
             case PLAIN:
                 if (with_coordinates) {
                     G_format_easting(Rast_col_to_easting(col + .5, &window),
@@ -123,6 +139,7 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels,
                                 category, "label",
                                 Rast_get_c_cat(&null_cell, &labels[i]));
                         break;
+                    case CSV:
                     case PLAIN:
                         fprintf(stdout, "%s%s", i ? fs : "", no_data_str);
                         if (with_labels)
@@ -141,6 +158,15 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels,
                                 category, "label",
                                 Rast_get_c_cat((CELL *)rastp[i], &labels[i]));
                         }
+                        break;
+                    case CSV:
+                        fprintf(stdout, "%s%ld", i ? fs : "",
+                                (long)*((CELL *)rastp[i]));
+                        if (with_labels)
+                            fprintf(stdout, "%s%s", fs,
+                                    !is_fp[i] ? Rast_get_c_cat((CELL *)rastp[i],
+                                                               &labels[i])
+                                              : no_data_str);
                         break;
                     case PLAIN:
                         fprintf(stdout, "%s%ld", i ? fs : "",
@@ -162,6 +188,7 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels,
                                 category, "label",
                                 Rast_get_f_cat((FCELL *)rastp[i], &labels[i]));
                         break;
+                    case CSV:
                     case PLAIN:
                         snprintf(str1, sizeof(str1), "%.8g",
                                  *((FCELL *)rastp[i]));
@@ -185,6 +212,7 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels,
                                 category, "label",
                                 Rast_get_d_cat((DCELL *)rastp[i], &labels[i]));
                         break;
+                    case CSV:
                     case PLAIN:
                         snprintf(str1, sizeof(str1), "%.16g",
                                  *((DCELL *)rastp[i]));
@@ -214,6 +242,7 @@ int raw_stats(int fd[], int with_coordinates, int with_xy, int with_labels,
                 json_object_set_value(object, "categories", categories_value);
                 json_array_append_value(array, object_value);
                 break;
+            case CSV:
             case PLAIN:
                 fprintf(stdout, "\n");
                 break;

--- a/raster/r.stats/stats.c
+++ b/raster/r.stats/stats.c
@@ -276,7 +276,7 @@ int print_cell_stats(char *fmt, int with_percents, int with_counts,
         if (format == CSV) {
             /* CSV Header */
             for (i = 0; i < nfiles; i++) {
-                fprintf(stdout, "%s%s", i ? fs : "", "cat");
+                fprintf(stdout, "%s%s_%s", i ? fs : "", map_names[i], "cat");
             }
             if (with_areas) {
                 fprintf(stdout, "%s%s", fs, "area");
@@ -318,14 +318,17 @@ int print_cell_stats(char *fmt, int with_percents, int with_counts,
             /* CSV Header */
             for (i = 0; i < nfiles; i++) {
                 if (raw_output || !is_fp[i] || as_int)
-                    fprintf(stdout, "%s%s", i ? fs : "", "cat");
+                    fprintf(stdout, "%s%s_%s", i ? fs : "", map_names[i],
+                            "cat");
                 else if (averaged)
-                    fprintf(stdout, "%s%s", i ? fs : "", "average");
+                    fprintf(stdout, "%s%s_%s", i ? fs : "", map_names[i],
+                            "average");
                 else
-                    fprintf(stdout, "%s%s", i ? fs : "", "range");
+                    fprintf(stdout, "%s%s_%s", i ? fs : "", map_names[i],
+                            "range");
 
                 if (with_labels)
-                    fprintf(stdout, "%s%s", fs, "label");
+                    fprintf(stdout, "%s%s_%s", fs, map_names[i], "label");
             }
 
             if (with_areas) {

--- a/raster/r.stats/testsuite/test_r_stats.py
+++ b/raster/r.stats/testsuite/test_r_stats.py
@@ -811,6 +811,277 @@ class TestRStats(TestCase):
         actual_output = json.loads(rstats_module.outputs.stdout)
         self.assertEqual(actual_output, expected_output)
 
+    def test_percentage_flag_csv_output(self):
+        """Verify that r.stats with the -p flag returns correct percentage values with CSV format.."""
+        rstats_module = SimpleModule(
+            "r.stats", input=self.test_raster_1, flags="p", format="csv"
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = ["cat,percent", "1,21.74%", "2,86.96%"]
+
+        actual_output = rstats_module.outputs.stdout.splitlines()
+        self.assertEqual(actual_output, expected_output)
+
+    def test_cross_tabulation_csv_output(self):
+        """Verify that r.stats with the -c flag produces correct cross-tabulation for multiple raster inputs with CSV format."""
+        rstats_module = SimpleModule(
+            "r.stats",
+            input=[self.test_raster_1, self.test_raster_2],
+            flags="c",
+            format="csv",
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = ["cat,cat,count", "1,1,5", "2,2,5", "2,3,5", "2,4,5", "2,*,5"]
+
+        actual_output = rstats_module.outputs.stdout.splitlines()
+        self.assertEqual(actual_output, expected_output)
+
+    def test_area_calculation_flag_csv_output(self):
+        """Verify that r.stats with the -a flag returns correct area calculations with CSV format."""
+        rstats_module = SimpleModule(
+            "r.stats", input=self.test_raster_1, flags="a", format="csv"
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = ["cat,area", "1,2000.000000", "2,8000.000000"]
+
+        actual_output = rstats_module.outputs.stdout.splitlines()
+        self.assertEqual(actual_output, expected_output)
+
+    def test_label_output_csv_flag(self):
+        """Verify that r.stats with the -l flag returns category labels correctly with CSV format."""
+        rstats_module = SimpleModule(
+            "r.stats", input=self.float_raster, flags="l", format="csv"
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            "range,label",
+            "0.5-0.515686,from 1 degrees to 1 degrees",
+            "0.986275-1.001961,from 1 degrees to 2 degrees",
+            "1.488235-1.503922,from 2 degrees to 3 degrees",
+            "1.990196-2.005882,from 3 degrees to 4 degrees",
+            "4.484314-4.5,from 7 degrees to 7 degrees",
+        ]
+
+        actual_output = rstats_module.outputs.stdout.splitlines()
+        self.assertEqual(actual_output, expected_output)
+
+    def test_grid_coordinates_csv_output(self):
+        """Verify that r.stats with the -g flag produces correct grid coordinates with CSV format."""
+        rstats_module = SimpleModule(
+            "r.stats", input=self.test_raster_1, flags="g", format="csv"
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            "east,north,cat",
+            "10,90,1",
+            "30,90,2",
+            "50,90,2",
+            "70,90,2",
+            "90,90,2",
+            "10,70,1",
+            "30,70,2",
+            "50,70,2",
+            "70,70,2",
+            "90,70,2",
+            "10,50,1",
+            "30,50,2",
+            "50,50,2",
+            "70,50,2",
+            "90,50,2",
+            "10,30,1",
+            "30,30,2",
+            "50,30,2",
+            "70,30,2",
+            "90,30,2",
+            "10,10,1",
+            "30,10,2",
+            "50,10,2",
+            "70,10,2",
+            "90,10,2",
+        ]
+
+        actual_output = rstats_module.outputs.stdout.splitlines()
+        self.assertEqual(actual_output, expected_output)
+
+    def test_cell_coordinates_csv_output(self):
+        """Verify that r.stats with the -x flag outputs row, column, and category values with CSV format."""
+        rstats_module = SimpleModule(
+            "r.stats", input=self.test_raster_1, flags="x", format="csv"
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            "col,row,cat",
+            "1,1,1",
+            "2,1,2",
+            "3,1,2",
+            "4,1,2",
+            "5,1,2",
+            "1,2,1",
+            "2,2,2",
+            "3,2,2",
+            "4,2,2",
+            "5,2,2",
+            "1,3,1",
+            "2,3,2",
+            "3,3,2",
+            "4,3,2",
+            "5,3,2",
+            "1,4,1",
+            "2,4,2",
+            "3,4,2",
+            "4,4,2",
+            "5,4,2",
+            "1,5,1",
+            "2,5,2",
+            "3,5,2",
+            "4,5,2",
+            "5,5,2",
+        ]
+
+        actual_output = rstats_module.outputs.stdout.splitlines()
+        self.assertEqual(actual_output, expected_output)
+
+    def test_area_statistics_csv_output(self):
+        """Verify that r.stats with the -A and -a flags outputs area statistics with CSV format."""
+        rstats_module = SimpleModule(
+            "r.stats",
+            input=self.float_raster,
+            flags="Aa",
+            format="csv",
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            "average,area",
+            "0.507843,2000.000000",
+            "0.994118,2000.000000",
+            "1.496078,2000.000000",
+            "1.998039,2000.000000",
+            "4.492157,2000.000000",
+        ]
+
+        actual_output = rstats_module.outputs.stdout.splitlines()
+        self.assertEqual(actual_output, expected_output)
+
+    def test_raw_index_area_csv_output(self):
+        """Verify that r.stats with -r and -a flags outputs raw indexes and corresponding area with CSV format."""
+        rstats_module = SimpleModule(
+            "r.stats", input=self.float_raster, flags="ra", format="csv"
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            "cat,area",
+            "1,2000.000000",
+            "32,2000.000000",
+            "64,2000.000000",
+            "96,2000.000000",
+            "255,2000.000000",
+        ]
+
+        actual_output = rstats_module.outputs.stdout.splitlines()
+        self.assertEqual(actual_output, expected_output)
+
+    def test_cats_range_csv_output(self):
+        """Verify that r.stats with -C and -l flags computes cats ranges and outputs labels with CSV format."""
+        rstats_module = SimpleModule(
+            "r.stats",
+            input=self.float_raster,
+            flags="Cl",
+            format="csv",
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            "range,label",
+            "0.5-1,1 degrees",
+            "1-1.5,2 degrees",
+            "2-2.5,4 degrees",
+            "4-4.5,7 degrees",
+        ]
+
+        actual_output = rstats_module.outputs.stdout.splitlines()
+        self.assertEqual(actual_output, expected_output)
+
+    def test_integer_category_counts_csv_output(self):
+        """Verify that r.stats with -i and -c flags outputs integer-rounded category values and their counts with CSV format."""
+        rstats_module = SimpleModule(
+            "r.stats",
+            input=self.float_raster,
+            flags="ic",
+            format="csv",
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = ["cat,count", "1,10", "2,10", "5,5"]
+
+        actual_output = rstats_module.outputs.stdout.splitlines()
+        self.assertEqual(actual_output, expected_output)
+
+    def test_multiple_raster_inputs_with_stats_csv_output(self):
+        """Verify r.stats with multiple raster inputs using -nacp flags and with CSV format."""
+        rstats_module = SimpleModule(
+            "r.stats",
+            input=[self.test_raster_1, self.test_raster_2],
+            flags="nacp",
+            format="csv",
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            "cat,cat,area,count,percent",
+            "1,1,2000.000000,5,33.33%",
+            "2,2,2000.000000,5,33.33%",
+            "2,3,2000.000000,5,33.33%",
+            "2,4,2000.000000,5,33.33%",
+        ]
+
+        actual_output = rstats_module.outputs.stdout.splitlines()
+        self.assertEqual(actual_output, expected_output)
+
+    def test_per_cell_label_csv_output(self):
+        """Test r.stats with -1ln flags to output per cell label with CSV format."""
+        rstats_module = SimpleModule(
+            "r.stats",
+            input=[self.test_raster_1, self.test_raster_2],
+            flags="1ln",
+            format="csv",
+        )
+        self.assertModule(rstats_module)
+
+        expected_output = [
+            "cat,label,cat,label",
+            "1,trees,1,trees",
+            "2,water,2,buildings",
+            "2,water,3,buildings",
+            "2,water,4,buildings",
+            "1,trees,1,trees",
+            "2,water,2,buildings",
+            "2,water,3,buildings",
+            "2,water,4,buildings",
+            "1,trees,1,trees",
+            "2,water,2,buildings",
+            "2,water,3,buildings",
+            "2,water,4,buildings",
+            "1,trees,1,trees",
+            "2,water,2,buildings",
+            "2,water,3,buildings",
+            "2,water,4,buildings",
+            "1,trees,1,trees",
+            "2,water,2,buildings",
+            "2,water,3,buildings",
+            "2,water,4,buildings",
+        ]
+
+        actual_output = rstats_module.outputs.stdout.splitlines()
+        self.assertEqual(actual_output, expected_output)
+
 
 if __name__ == "__main__":
     test()

--- a/raster/r.stats/testsuite/test_r_stats.py
+++ b/raster/r.stats/testsuite/test_r_stats.py
@@ -818,7 +818,7 @@ class TestRStats(TestCase):
         )
         self.assertModule(rstats_module)
 
-        expected_output = ["cat,percent", "1,21.74%", "2,86.96%"]
+        expected_output = ["test_raster_1_cat,percent", "1,21.74%", "2,86.96%"]
 
         actual_output = rstats_module.outputs.stdout.splitlines()
         self.assertEqual(actual_output, expected_output)
@@ -833,7 +833,14 @@ class TestRStats(TestCase):
         )
         self.assertModule(rstats_module)
 
-        expected_output = ["cat,cat,count", "1,1,5", "2,2,5", "2,3,5", "2,4,5", "2,*,5"]
+        expected_output = [
+            "test_raster_1_cat,test_raster_2_cat,count",
+            "1,1,5",
+            "2,2,5",
+            "2,3,5",
+            "2,4,5",
+            "2,*,5",
+        ]
 
         actual_output = rstats_module.outputs.stdout.splitlines()
         self.assertEqual(actual_output, expected_output)
@@ -845,7 +852,7 @@ class TestRStats(TestCase):
         )
         self.assertModule(rstats_module)
 
-        expected_output = ["cat,area", "1,2000.000000", "2,8000.000000"]
+        expected_output = ["test_raster_1_cat,area", "1,2000.000000", "2,8000.000000"]
 
         actual_output = rstats_module.outputs.stdout.splitlines()
         self.assertEqual(actual_output, expected_output)
@@ -858,7 +865,7 @@ class TestRStats(TestCase):
         self.assertModule(rstats_module)
 
         expected_output = [
-            "range,label",
+            "float_raster_range,float_raster_label",
             "0.5-0.515686,from 1 degrees to 1 degrees",
             "0.986275-1.001961,from 1 degrees to 2 degrees",
             "1.488235-1.503922,from 2 degrees to 3 degrees",
@@ -877,7 +884,7 @@ class TestRStats(TestCase):
         self.assertModule(rstats_module)
 
         expected_output = [
-            "east,north,cat",
+            "east,north,test_raster_1_cat",
             "10,90,1",
             "30,90,2",
             "50,90,2",
@@ -916,7 +923,7 @@ class TestRStats(TestCase):
         self.assertModule(rstats_module)
 
         expected_output = [
-            "col,row,cat",
+            "col,row,test_raster_1_cat",
             "1,1,1",
             "2,1,2",
             "3,1,2",
@@ -958,7 +965,7 @@ class TestRStats(TestCase):
         self.assertModule(rstats_module)
 
         expected_output = [
-            "average,area",
+            "float_raster_average,area",
             "0.507843,2000.000000",
             "0.994118,2000.000000",
             "1.496078,2000.000000",
@@ -977,7 +984,7 @@ class TestRStats(TestCase):
         self.assertModule(rstats_module)
 
         expected_output = [
-            "cat,area",
+            "float_raster_cat,area",
             "1,2000.000000",
             "32,2000.000000",
             "64,2000.000000",
@@ -999,7 +1006,7 @@ class TestRStats(TestCase):
         self.assertModule(rstats_module)
 
         expected_output = [
-            "range,label",
+            "float_raster_range,float_raster_label",
             "0.5-1,1 degrees",
             "1-1.5,2 degrees",
             "2-2.5,4 degrees",
@@ -1019,7 +1026,7 @@ class TestRStats(TestCase):
         )
         self.assertModule(rstats_module)
 
-        expected_output = ["cat,count", "1,10", "2,10", "5,5"]
+        expected_output = ["float_raster_cat,count", "1,10", "2,10", "5,5"]
 
         actual_output = rstats_module.outputs.stdout.splitlines()
         self.assertEqual(actual_output, expected_output)
@@ -1035,7 +1042,7 @@ class TestRStats(TestCase):
         self.assertModule(rstats_module)
 
         expected_output = [
-            "cat,cat,area,count,percent",
+            "test_raster_1_cat,test_raster_2_cat,area,count,percent",
             "1,1,2000.000000,5,33.33%",
             "2,2,2000.000000,5,33.33%",
             "2,3,2000.000000,5,33.33%",
@@ -1056,7 +1063,7 @@ class TestRStats(TestCase):
         self.assertModule(rstats_module)
 
         expected_output = [
-            "cat,label,cat,label",
+            "test_raster_1_cat,test_raster_1_label,test_raster_2_cat,test_raster_2_label",
             "1,trees,1,trees",
             "2,water,2,buildings",
             "2,water,3,buildings",


### PR DESCRIPTION
Added CSV output support for `r.stats`, including headers. Note that the `cat`/`average`/`range` and `label` may appear multiple times when processing multiple rasters.
Let me know if this makes sense or if it needs to be updated?

I also attempted to add JSONL support but had some doubts. Even with JSONL, the schema would remain hierarchical since there can be more than one map, and we need arrays to represent their categories. So, the JSONL format would resemble the current JSON format but without the outer array.